### PR TITLE
Support LS30_DEVICES variable

### DIFF
--- a/bin/list-devices.pl
+++ b/bin/list-devices.pl
@@ -25,7 +25,12 @@ use vars qw($opt_h $opt_v $opt_y);
 
 getopts('h:vy');
 
-my $devices_file = "etc/devices.yaml";
+my $devices_file = $ENV{'LS30_DEVICES'};
+
+if(!$devices_file)
+{
+ 	$devices_file = "etc/devices.yaml";
+}
 
 my $ls30c = LS30Connection->new($opt_h);
 


### PR DESCRIPTION
Please check this will still work as expected if LS30_DEVICES is not provided. I think it will, but just in case!
